### PR TITLE
Fix regex pattern escaping

### DIFF
--- a/custom_patterns.py
+++ b/custom_patterns.py
@@ -2,17 +2,16 @@
 # This file stores user-defined regex patterns.
 
 MODEL_PATTERNS = [
-    r'\\\\\\\\bFS-\\\\\\\\d+[A-Z]*\\\\\\\\b',
-    r'\\\\\\\\bKM-\\\\\\\\d+[A-Z]*\\\\\\\\b',
-    r'\\\\\\\\bECOSYS\\\\\\\\s+[A-Z]+\\\\\\\\d+[a-z]*\\\\\\\\b',
-    r'\\\\\\\\bTASKalfa\\\\\\\\s+\\\\\\\\d+[a-z]*\\\\\\\\b',
-    r'\\\\\\\\bPF-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bDF-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bMK-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bDV-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bTASKalfa\\\\\\\\ Pro\\\\\\\\ \\\\\\\\d+c\\\\\\\\b',
-    r'\\bTASKalfa\\ Pro\\ \\d+c\\b',
+    r"\bFS-\d+[A-Z]*\b",
+    r"\bKM-\d+[A-Z]*\b",
+    r"\bECOSYS\s+[A-Z]+\d+[a-z]*\b",
+    r"\bTASKalfa\s+\d+[a-z]*\b",
+    r"\bPF-\d+\b",
+    r"\bDF-\d+\b",
+    r"\bMK-\d+\b",
+    r"\bDV-\d+\b",
+    r"\bTASKalfa Pro \d+c\b",
+    r"\bTASKalfa Pro \d+c\b",
 ]
 
-QA_NUMBER_PATTERNS = [
-]
+QA_NUMBER_PATTERNS = []

--- a/tests/test_custom_patterns_unit.py
+++ b/tests/test_custom_patterns_unit.py
@@ -1,0 +1,19 @@
+import unittest
+import re
+import custom_patterns
+
+
+class TestCustomPatterns(unittest.TestCase):
+    def test_first_pattern_simplified(self):
+        self.assertEqual(custom_patterns.MODEL_PATTERNS[0], r"\bFS-\d+[A-Z]*\b")
+
+    def test_patterns_compile(self):
+        for pat in custom_patterns.MODEL_PATTERNS:
+            try:
+                re.compile(pat)
+            except re.error as exc:
+                self.fail(f"Pattern {pat} failed to compile: {exc}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- simplify regex definitions in `custom_patterns.py`
- format files with `black`
- add tests verifying regex patterns compile

## Testing
- `python -m py_compile custom_patterns.py`
- `python -m unittest discover -v`
- `black --check custom_patterns.py tests/test_custom_patterns_unit.py`


------
https://chatgpt.com/codex/tasks/task_e_686f2be9afdc832e93d7f6e7da1e9c30