### PR TITLE
Fix regex pattern file

### DIFF
--- a/custom_patterns.py
+++ b/custom_patterns.py
@@ -2,17 +2,19 @@
 # This file stores user-defined regex patterns.
 
 MODEL_PATTERNS = [
-    r'\\\\\\\\bFS-\\\\\\\\d+[A-Z]*\\\\\\\\b',
-    r'\\\\\\\\bKM-\\\\\\\\d+[A-Z]*\\\\\\\\b',
-    r'\\\\\\\\bECOSYS\\\\\\\\s+[A-Z]+\\\\\\\\d+[a-z]*\\\\\\\\b',
-    r'\\\\\\\\bTASKalfa\\\\\\\\s+\\\\\\\\d+[a-z]*\\\\\\\\b',
-    r'\\\\\\\\bPF-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bDF-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bMK-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bDV-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bTASKalfa\\\\\\\\ Pro\\\\\\\\ \\\\\\\\d+c\\\\\\\\b',
-    r'\\bTASKalfa\\ Pro\\ \\d+c\\b',
+    r'\bFS-\d+[A-Z]*\b',
+    r'\bKM-\d+[A-Z]*\b',
+    r'\bECOSYS\s+[A-Z]+\d+[a-z]*\b',
+    r'\bTASKalfa\s+\d+[a-z]*\b',
+    r'\bPF-\d+\b',
+    r'\bDF-\d+\b',
+    r'\bMK-\d+\b',
+    r'\bDV-\d+\b',
+    r'\bTASKalfa Pro \d+c\b',
+    r'\bTASKalfa Pro \d+c\b',
 ]
 
 QA_NUMBER_PATTERNS = [
+    r'\bQA-\d+\b',
+    r'\bSB-\d+\b',
 ]

--- a/test_pattern_compilation.py
+++ b/test_pattern_compilation.py
@@ -1,0 +1,18 @@
+import unittest
+import re
+import importlib
+
+import custom_patterns
+
+class TestPatternCompilation(unittest.TestCase):
+    def test_patterns_compile(self):
+        """Ensure all regex patterns compile successfully."""
+        importlib.reload(custom_patterns)
+        for pattern in custom_patterns.MODEL_PATTERNS + custom_patterns.QA_NUMBER_PATTERNS:
+            try:
+                re.compile(pattern)
+            except re.error as e:
+                self.fail(f"Pattern {pattern!r} failed to compile: {e}")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- simplify regex strings in `custom_patterns.py`
- add QA number patterns
- create `test_pattern_compilation.py` to ensure patterns compile

## Testing
- `python -m py_compile custom_patterns.py`
- `python test_pattern_compilation.py > /tmp/test_output.txt 2>&1 && tail -n 20 /tmp/test_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_686f2c745da0832e835c734e8ba4f554