### PR TITLE
Fix quoting in OCR config

### DIFF
--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -248,7 +248,7 @@ def extract_text_with_ocr(pdf_path):
                     denoised = cv2.medianBlur(binary_img, 3)
                     
                     # OCR with optimized settings
-                    custom_config = r'--oem 3 --psm 6 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.,;:!?-_()[]{}@#$%^&*+=<>/\|"'''
+                    custom_config = r'--oem 3 --psm 6 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.,;:!?-_()[]{}@#$%^&*+=<>/\|"'
                     page_text = pytesseract.image_to_string(denoised, lang='eng', config=custom_config)
                     
                     if page_text.strip():

--- a/tests/test_ocr_utils_compile.py
+++ b/tests/test_ocr_utils_compile.py
@@ -1,0 +1,8 @@
+import py_compile
+from pathlib import Path
+
+def test_compile_ocr_utils():
+    try:
+        py_compile.compile(str(Path(__file__).resolve().parents[1] / 'ocr_utils.py'), doraise=True)
+    except py_compile.PyCompileError as e:
+        assert False, f"Compilation failed: {e}"


### PR DESCRIPTION
## Summary
- fix the extra quotes in `ocr_utils.py`
- add a unit test that ensures the file compiles

## Testing
- `pytest tests/test_ocr_utils_compile.py -q`
- `python -m py_compile ocr_utils.py`
- `python -m flake8 ocr_utils.py` *(fails: No module named flake8)*

------
https://chatgpt.com/codex/tasks/task_e_686f2bfd2db0832e97fe3cfba25166a4