### PR TITLE
Fix custom patterns syntax and add unit tests

### DIFF
--- a/custom_patterns.py
+++ b/custom_patterns.py
@@ -2,17 +2,20 @@
 # This file stores user-defined regex patterns.
 
 MODEL_PATTERNS = [
-    r'\\\\\\\\bFS-\\\\\\\\d+[A-Z]*\\\\\\\\b',
-    r'\\\\\\\\bKM-\\\\\\\\d+[A-Z]*\\\\\\\\b',
-    r'\\\\\\\\bECOSYS\\\\\\\\s+[A-Z]+\\\\\\\\d+[a-z]*\\\\\\\\b',
-    r'\\\\\\\\bTASKalfa\\\\\\\\s+\\\\\\\\d+[a-z]*\\\\\\\\b',
-    r'\\\\\\\\bPF-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bDF-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bMK-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bDV-\\\\\\\\d+\\\\\\\\b',
-    r'\\\\\\\\bTASKalfa\\\\\\\\ Pro\\\\\\\\ \\\\\\\\d+c\\\\\\\\b',
-    r'\\bTASKalfa\\ Pro\\ \\d+c\\b',
+    # Standard Kyocera model formats
+    r'\bFS-\d+[A-Z]*\b',
+    r'\bKM-\d+[A-Z]*\b',
+    r'\bECOSYS\s+[A-Z]+\d+[a-z]*\b',
+    r'\bTASKalfa\s+\d+[a-z]*\b',
+    r'\bPF-\d+\b',
+    r'\bDF-\d+\b',
+    r'\bMK-\d+\b',
+    r'\bDV-\d+\b',
+    # High-end production models
+    r'\bTASKalfa Pro \d+c\b',
 ]
 
 QA_NUMBER_PATTERNS = [
+    r'\bQA-\d+\b',
+    r'\bSB-\d+\b',
 ]

--- a/test_data_harvesters.py
+++ b/test_data_harvesters.py
@@ -1,0 +1,23 @@
+import unittest
+
+from data_harvesters import get_combined_patterns, harvest_models
+from config import MODEL_PATTERNS as DEFAULT_MODEL_PATTERNS
+from custom_patterns import MODEL_PATTERNS as CUSTOM_MODEL_PATTERNS
+
+
+class TestDataHarvesters(unittest.TestCase):
+    def test_combined_patterns_include_custom_and_default(self):
+        combined = get_combined_patterns("MODEL_PATTERNS", DEFAULT_MODEL_PATTERNS)
+        for pattern in CUSTOM_MODEL_PATTERNS:
+            self.assertIn(pattern, combined)
+        for pattern in DEFAULT_MODEL_PATTERNS:
+            self.assertIn(pattern, combined)
+
+    def test_harvest_models_with_custom_pattern(self):
+        text = "Example FS-1234MFP document"
+        found = harvest_models(text, "sample.pdf")
+        self.assertIn("FS-1234MFP", found)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- clean up `custom_patterns.py` with readable regex patterns
- add QA number patterns for completeness
- create `test_data_harvesters.py` with unit tests for pattern combination and model harvesting

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `printf '1\n\n' | python test_custom_patterns.py`
- `python -m unittest test_data_harvesters.py -v`


------
https://chatgpt.com/codex/tasks/task_e_686f2c0eb1f4832eadc80c9b2166e8d6