### PR TITLE
Fix requirements typo and add test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ ollama>=0.3.3
 ## Utilities
 colorama>=0.4.6
 python-dateutil>=2.9.0
-extract

--- a/tests/test_requirements_file.py
+++ b/tests/test_requirements_file.py
@@ -1,0 +1,6 @@
+import pathlib
+
+
+def test_no_extract_package():
+    requirements = pathlib.Path('requirements.txt').read_text().splitlines()
+    assert 'extract' not in requirements, "requirements.txt should not contain the 'extract' package"


### PR DESCRIPTION
## Summary
- drop leftover `extract` line from requirements.txt
- add a regression test to ensure it stays clean

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_requirements_file.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f3516e964832e8728adbc1e090723