### PR TITLE
Add template support in Excel generation

### DIFF
--- a/excel_generator.py
+++ b/excel_generator.py
@@ -148,7 +148,14 @@ class ExcelWriter:
             apply_excel_styles(writer.sheets["ServiceNow Import"], df)
             writer.save()
 
-def generate_excel(all_results, output_path, template_path):
+def generate_excel(all_results, output_path, template_path=None):
+    """Generate a formatted Excel file for ServiceNow imports.
+
+    If ``template_path`` is provided an existing workbook is cloned and the
+    DataFrame is written into that workbook preserving its formatting.  When no
+    template is supplied, a fresh workbook is created instead.
+    """
+
     try:
         if not all_results:
             raise ExcelGenerationError("No data to generate.")
@@ -167,10 +174,24 @@ def generate_excel(all_results, output_path, template_path):
             columns=[c for c in internal_cols if c in final_df.columns], errors="ignore"
         )
 
-        with pd.ExcelWriter(output_path, engine="openpyxl") as writer:
-            df_to_save.to_excel(writer, index=False, sheet_name="ServiceNow Import")
-            apply_excel_styles(writer.sheets["ServiceNow Import"], df_sanitized)
-            writer.save()
+        if template_path:
+            wb = openpyxl.load_workbook(template_path)
+            ws = wb.active
+            # remove any existing data rows (keep headers if present)
+            if ws.max_row > 1:
+                ws.delete_rows(2, ws.max_row - 1)
+            for r_idx, row in enumerate(
+                dataframe_to_rows(df_to_save, index=False, header=True), start=1
+            ):
+                for c_idx, value in enumerate(row, start=1):
+                    ws.cell(row=r_idx, column=c_idx, value=value)
+            apply_excel_styles(ws, df_sanitized)
+            wb.save(output_path)
+        else:
+            with pd.ExcelWriter(output_path, engine="openpyxl") as writer:
+                df_to_save.to_excel(writer, index=False, sheet_name="ServiceNow Import")
+                apply_excel_styles(writer.sheets["ServiceNow Import"], df_sanitized)
+                writer.save()
 
         log_info(logger, f"Successfully created formatted Excel file: {output_path}")
         return str(output_path)

--- a/test_excel_generator.py
+++ b/test_excel_generator.py
@@ -10,10 +10,28 @@ def test_generate_excel_headers(tmp_path):
         {"Short description": "Test", "Article body": "body"}
     ])
     output_file = tmp_path / "out.xlsx"
-    generate_excel(sample_df.to_dict("records"), output_file, None)
+    generate_excel(sample_df.to_dict("records"), output_file)
     assert output_file.exists()
 
     wb = load_workbook(output_file)
     ws = wb.active
     headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
     assert headers == DEFAULT_TEMPLATE_HEADERS
+
+
+def test_generate_excel_with_template(tmp_path):
+    sample_df = pd.DataFrame([
+        {"Short description": "Test", "Article body": "body"}
+    ])
+    output_file = tmp_path / "out_template.xlsx"
+    template = Path("Sample_Set/kb_knowledge_Template.xlsx")
+    generate_excel(sample_df.to_dict("records"), output_file, template)
+    assert output_file.exists()
+
+    wb = load_workbook(output_file)
+    ws = wb.active
+    headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+    assert headers == DEFAULT_TEMPLATE_HEADERS
+    assert ws.max_row == 2
+    sd_index = DEFAULT_TEMPLATE_HEADERS.index("Short description") + 1
+    assert ws.cell(row=2, column=sd_index).value == "Test"


### PR DESCRIPTION
## Summary
- allow `excel_generator.generate_excel` to clone a template workbook
- add integration tests for template cloning

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -k excel_generator -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f3532126c832e9cf07b30c950cfd5