### PR TITLE
Handle progress messages and reset bar

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -345,6 +345,10 @@ class KyoQAToolApp(tk.Tk):
                             data.get("reason", "N/A"),
                         ),
                     )
+                elif mtype == "progress":
+                    total = msg.get("total", 1) or 1
+                    current = msg.get("current", 0)
+                    self.progress_value.set((current / total) * 100)
                 elif mtype == "finish":
                     status = msg.get("status", "Complete")
                     self.log_message(f"Job finished: {status}")
@@ -369,6 +373,7 @@ class KyoQAToolApp(tk.Tk):
         self.process_btn.config(state=tk.DISABLED); self.rerun_btn.config(state=tk.DISABLED)
         self.open_result_btn.config(state=tk.DISABLED)
         self.pause_btn.config(state=tk.NORMAL); self.stop_btn.config(state=tk.NORMAL)
+        self.progress_value.set(0)
         self.set_led("Processing")
 
     def update_ui_for_finish(self, status):

--- a/test_kyo_qa_tool_app.py
+++ b/test_kyo_qa_tool_app.py
@@ -56,6 +56,7 @@ def make_dummy_app():
         "count_no_text",
     ]:
         setattr(dummy, name, DummyVar(1))
+    dummy.progress_value = DummyVar(50)
     dummy.reviewable_files = [1]
     dummy.review_tree = DummyReviewTree()
     dummy.process_btn = DummyButton()
@@ -77,3 +78,9 @@ def test_update_ui_for_start_resets_state():
     assert app.pause_btn.kwargs["state"] == tk.NORMAL
     assert app.count_pass.get() == 0
     assert app.review_tree.get_children() == []
+
+
+def test_update_ui_for_start_resets_progress():
+    app = make_dummy_app()
+    KyoQAToolApp.update_ui_for_start(app)
+    assert app.progress_value.get() == 0

--- a/test_process_response_queue.py
+++ b/test_process_response_queue.py
@@ -30,6 +30,9 @@ class DummyVar:
     def set(self, value):
         self.value = value
 
+    def get(self):
+        return getattr(self, "value", 0)
+
 class DummyTree:
     def insert(self, *a, **k):
         pass
@@ -44,6 +47,7 @@ class DummyApp:
         self.reviewable_files = []
         self.review_tree = DummyTree()
         self.result_file_path = None
+        self.progress_value = DummyVar()
     def log_message(self, msg):
         pass
     def update_ui_for_finish(self, status):
@@ -60,3 +64,11 @@ def test_enable_open_result_message():
     app.response_queue.put({"type": "enable_open_result"})
     app.process_response_queue()
     assert app.open_result_btn.state == tk.NORMAL
+
+
+def test_progress_message_updates_value():
+    app = DummyApp()
+    app.process_response_queue = MethodType(KyoQAToolApp.process_response_queue, app)
+    app.response_queue.put({"type": "progress", "current": 2, "total": 4})
+    app.process_response_queue()
+    assert app.progress_value.get() == 50.0


### PR DESCRIPTION
## Summary
- handle `progress` messages in `process_response_queue`
- reset progress bar when processing starts
- test progress update logic and bar reset

## Testing
- `ruff check . | head`
- `pytest -q 2>&1 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_686f3543a928832e92d398153c4ab135