### PR TITLE
Implement LED status updates

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -437,28 +437,9 @@ class KyoQAToolApp(tk.Tk):
     def open_pattern_manager(self):
         ReviewWindow(self, "MODEL_PATTERNS", "Model Patterns", None)
     def set_led(self, status):
-        """Update the small status LED and bar colour."""
-        color_map = {
-            "Ready": BRAND_COLORS.get("accent_blue"),
-            "Processing": BRAND_COLORS.get("success_green"),
-            "Paused": BRAND_COLORS.get("warning_orange"),
-            "OCR": BRAND_COLORS.get("warning_orange"),
-            "AI": BRAND_COLORS.get("accent_blue"),
-            "Saving": BRAND_COLORS.get("accent_blue"),
-            "Complete": BRAND_COLORS.get("success_green"),
-            "Cancelled": BRAND_COLORS.get("fail_red"),
-            "Error": BRAND_COLORS.get("fail_red"),
-        }
-
-        bg_map = {
-            "Processing": BRAND_COLORS.get("status_processing_bg"),
-            "OCR": BRAND_COLORS.get("status_ocr_bg"),
-            "AI": BRAND_COLORS.get("status_ai_bg"),
-        }
-
+        """Update the small status LED icon and background colour."""
         self.led_status_var.set("●")
-        fg = color_map.get(status, BRAND_COLORS.get("accent_blue"))
-        bg = bg_map.get(status, BRAND_COLORS.get("status_default_bg"))
+        fg, bg = get_led_colors(status)
 
         self.status_frame.configure(background=bg)
         self.led_label.configure(foreground=fg, background=bg)

--- a/tests/test_led.py
+++ b/tests/test_led.py
@@ -31,5 +31,16 @@ def test_set_led_processing():
     app.status_frame = DummyWidget()
     KyoQAToolApp.set_led(app, "Processing")
     assert app.led_status_var.get() == "●"
-    assert app.led_label.config_called["foreground"] == BRAND_COLORS["success_green"]
+    assert app.led_label.config_called["foreground"] == BRAND_COLORS["accent_blue"]
     assert app.status_frame.config_called["background"] == BRAND_COLORS["status_processing_bg"]
+
+
+def test_set_led_error():
+    app = types.SimpleNamespace()
+    app.led_status_var = DummyVar()
+    app.led_label = DummyWidget()
+    app.status_frame = DummyWidget()
+    KyoQAToolApp.set_led(app, "Error")
+    assert app.led_status_var.get() == "●"
+    assert app.led_label.config_called["foreground"] == BRAND_COLORS["fail_red"]
+    assert app.status_frame.config_called["background"] == BRAND_COLORS["status_default_bg"]


### PR DESCRIPTION
## Summary
- implement `set_led()` with color lookup via `get_led_colors`
- update LED unit test for accent blue
- add test for `Error` status

## Testing
- `ruff check tests/test_led.py kyo_qa_tool_app.py`
- `pytest tests/test_led.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f3545d3f8832e936c76335c38f8a1