### PR TITLE
Implement LED symbol updates

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -121,7 +121,7 @@ class KyoQAToolApp(tk.Tk):
         # UI Vars
         self.selected_folder, self.selected_excel = tk.StringVar(), tk.StringVar()
         self.status_current_file, self.progress_value = tk.StringVar(value="Ready to process"), tk.DoubleVar()
-        self.time_remaining_var, self.led_status_var = tk.StringVar(), tk.StringVar(value="●")
+        self.time_remaining_var, self.led_status_var = tk.StringVar(), tk.StringVar(value="\u26AA")
 
         check_and_create_icons()
         self._load_icons()
@@ -377,7 +377,7 @@ class KyoQAToolApp(tk.Tk):
         self.process_btn.config(state=tk.NORMAL)
         if self.reviewable_files: self.rerun_btn.config(state=tk.NORMAL)
         self.pause_btn.config(state=tk.DISABLED); self.stop_btn.config(state=tk.DISABLED)
-        self.set_led(status if status == "Complete" else "Error")
+        self.set_led("Ready" if status == "Complete" else "Error")
 
     def log_message(self, message, level="info"):
         self.log_text.config(state=tk.NORMAL)
@@ -437,31 +437,23 @@ class KyoQAToolApp(tk.Tk):
     def open_pattern_manager(self):
         ReviewWindow(self, "MODEL_PATTERNS", "Model Patterns", None)
     def set_led(self, status):
-        """Update the small status LED and bar colour."""
-        color_map = {
-            "Ready": BRAND_COLORS.get("accent_blue"),
-            "Processing": BRAND_COLORS.get("success_green"),
-            "Paused": BRAND_COLORS.get("warning_orange"),
-            "OCR": BRAND_COLORS.get("warning_orange"),
-            "AI": BRAND_COLORS.get("accent_blue"),
-            "Saving": BRAND_COLORS.get("accent_blue"),
-            "Complete": BRAND_COLORS.get("success_green"),
-            "Cancelled": BRAND_COLORS.get("fail_red"),
-            "Error": BRAND_COLORS.get("fail_red"),
+        """Set the LED symbol and highlight colour based on status."""
+        symbol_map = {
+            "Ready": "\U0001F7E2",       # green circle
+            "Processing": "\U0001F535",  # blue circle
+            "OCR": "\U0001F7E0",        # orange circle
+            "Error": "\U0001F534",      # red circle
         }
-
         bg_map = {
             "Processing": BRAND_COLORS.get("status_processing_bg"),
             "OCR": BRAND_COLORS.get("status_ocr_bg"),
-            "AI": BRAND_COLORS.get("status_ai_bg"),
         }
 
-        self.led_status_var.set("●")
-        fg = color_map.get(status, BRAND_COLORS.get("accent_blue"))
-        bg = bg_map.get(status, BRAND_COLORS.get("status_default_bg"))
+        self.led_status_var.set(symbol_map.get(status, "\u26AA"))
 
+        bg = bg_map.get(status, BRAND_COLORS.get("status_default_bg"))
         self.status_frame.configure(background=bg)
-        self.led_label.configure(foreground=fg, background=bg)
+        self.led_label.configure(background=bg)
         for child in self.status_frame.winfo_children():
             try:
                 child.configure(background=bg)

--- a/test_kyo_qa_tool_app.py
+++ b/test_kyo_qa_tool_app.py
@@ -34,6 +34,10 @@ class DummyButton:
         self.kwargs = {}
     def config(self, **kwargs):
         self.kwargs.update(kwargs)
+    def configure(self, **kwargs):
+        self.kwargs.update(kwargs)
+    def winfo_children(self):
+        return []
 
 class DummyReviewTree:
     def __init__(self):
@@ -60,12 +64,17 @@ def make_dummy_app():
     dummy.review_tree = DummyReviewTree()
     dummy.process_btn = DummyButton()
     dummy.rerun_btn = DummyButton()
+    dummy.open_result_btn = DummyButton()
     dummy.pause_btn = DummyButton()
     dummy.stop_btn = DummyButton()
+    dummy.status_frame = DummyButton()
+    dummy.led_label = DummyButton()
+    dummy.led_status_var = DummyVar()
     dummy.cancel_event = types.SimpleNamespace(clear=lambda: None)
     dummy.pause_event = types.SimpleNamespace(clear=lambda: None)
     dummy.is_processing = False
     dummy.is_paused = True
+    dummy.set_led = KyoQAToolApp.set_led.__get__(dummy)
     return dummy
 
 def test_update_ui_for_start_resets_state():
@@ -77,3 +86,11 @@ def test_update_ui_for_start_resets_state():
     assert app.pause_btn.kwargs["state"] == tk.NORMAL
     assert app.count_pass.get() == 0
     assert app.review_tree.get_children() == []
+
+def test_update_ui_for_finish_sets_ready_led():
+    app = make_dummy_app()
+    app.led_status_var = DummyVar()
+    app.status_frame = DummyButton()
+    app.led_label = DummyButton()
+    KyoQAToolApp.update_ui_for_finish(app, "Complete")
+    assert app.led_status_var.get() == "\U0001F7E2"

--- a/tests/test_led.py
+++ b/tests/test_led.py
@@ -30,6 +30,5 @@ def test_set_led_processing():
     app.led_label = DummyWidget()
     app.status_frame = DummyWidget()
     KyoQAToolApp.set_led(app, "Processing")
-    assert app.led_status_var.get() == "●"
-    assert app.led_label.config_called["foreground"] == BRAND_COLORS["success_green"]
+    assert app.led_status_var.get() == "\U0001F535"
     assert app.status_frame.config_called["background"] == BRAND_COLORS["status_processing_bg"]


### PR DESCRIPTION
## Summary
- adjust LED handling in `set_led` to show status with colored symbols
- reset LED after finishing processing
- update tests for new LED logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_led.py test_kyo_qa_tool_app.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f35273164832e82e7b7f16712a9a6