### PR TITLE
Improve Excel generation using template workbook

### DIFF
--- a/excel_generator.py
+++ b/excel_generator.py
@@ -5,8 +5,6 @@ import pandas as pd
 from openpyxl.styles import Alignment, Font, PatternFill
 from openpyxl.formatting.rule import FormulaRule
 import openpyxl
-from openpyxl.utils.dataframe import dataframe_to_rows
-from openpyxl.worksheet.copier import WorksheetCopy
 import re
 
 from logging_utils import setup_logger, log_info, log_error
@@ -167,10 +165,17 @@ def generate_excel(all_results, output_path, template_path):
             columns=[c for c in internal_cols if c in final_df.columns], errors="ignore"
         )
 
+        if template_path:
+            workbook = openpyxl.load_workbook(template_path)
+        else:
+            workbook = openpyxl.Workbook()
+
         with pd.ExcelWriter(output_path, engine="openpyxl") as writer:
+            writer.book = workbook
+            writer.sheets = {ws.title: ws for ws in workbook.worksheets}
             df_to_save.to_excel(writer, index=False, sheet_name="ServiceNow Import")
             apply_excel_styles(writer.sheets["ServiceNow Import"], df_sanitized)
-            writer.save()
+            writer.book.save(output_path)
 
         log_info(logger, f"Successfully created formatted Excel file: {output_path}")
         return str(output_path)

--- a/test_excel_generator.py
+++ b/test_excel_generator.py
@@ -1,6 +1,5 @@
 import pandas as pd
-from pathlib import Path
-from openpyxl import load_workbook
+from openpyxl import load_workbook, Workbook
 
 from excel_generator import generate_excel, DEFAULT_TEMPLATE_HEADERS
 
@@ -17,3 +16,20 @@ def test_generate_excel_headers(tmp_path):
     ws = wb.active
     headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
     assert headers == DEFAULT_TEMPLATE_HEADERS
+
+
+def test_generate_excel_with_template(tmp_path):
+    data = [{"Short description": "Test", "Article body": "body"}]
+
+    template = tmp_path / "template.xlsx"
+    wb = Workbook()
+    wb.active.title = "Existing"
+    wb.save(template)
+
+    output_file = tmp_path / "out_template.xlsx"
+    generate_excel(data, output_file, template)
+
+    assert output_file.exists()
+    out_wb = load_workbook(output_file)
+    assert "Existing" in out_wb.sheetnames
+    assert "ServiceNow Import" in out_wb.sheetnames


### PR DESCRIPTION
## Summary
- fix unused imports for lint compliance
- enhance `generate_excel` to load a workbook template with `openpyxl` and save via the writer's `book`
- add regression test ensuring templates are preserved when generating Excel output

## Testing
- `ruff check excel_generator.py test_excel_generator.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f34f07064832e868e9a79b1aab249