### PR TITLE
Fix custom patterns

### DIFF
--- a/custom_patterns.py
+++ b/custom_patterns.py
@@ -2,16 +2,18 @@
 # This file stores user-defined regex patterns.
 
 MODEL_PATTERNS = [
-    r"\bFS-\d+[A-Z]*\b",
-    r"\bKM-\d+[A-Z]*\b",
-    r"\bECOSYS\s+[A-Z]+\d+[a-z]*\b",
-    r"\bTASKalfa\s+\d+[a-z]*\b",
-    r"\bPF-\d+\b",
-    r"\bDF-\d+\b",
-    r"\bMK-\d+\b",
-    r"\bDV-\d+\b",
-    r"\bTASKalfa Pro \d+c\b",
-    r"\bTASKalfa Pro \d+c\b",
+    r'\bFS-\d+[A-Z]*\b',
+    r'\bKM-\d+[A-Z]*\b',
+    r'\bECOSYS\s+[A-Z]+\d+[a-z]*\b',
+    r'\bTASKalfa\s+\d+[a-z]*\b',
+    r'\bPF-\d+\b',
+    r'\bDF-\d+\b',
+    r'\bMK-\d+\b',
+    r'\bDV-\d+\b',
+    r'\bTASKalfa Pro \d+c\b',
 ]
 
-QA_NUMBER_PATTERNS = []
+QA_NUMBER_PATTERNS = [
+    r'\bQA-\d+\b',
+    r'\bSB-\d+\b',
+]

--- a/tests/test_custom_patterns_unit.py
+++ b/tests/test_custom_patterns_unit.py
@@ -14,6 +14,14 @@ class TestCustomPatterns(unittest.TestCase):
             except re.error as exc:
                 self.fail(f"Pattern {pat} failed to compile: {exc}")
 
+    def test_qa_patterns_present_and_compile(self):
+        self.assertGreater(len(custom_patterns.QA_NUMBER_PATTERNS), 0)
+        for pat in custom_patterns.QA_NUMBER_PATTERNS:
+            try:
+                re.compile(pat)
+            except re.error as exc:
+                self.fail(f"QA pattern {pat} failed to compile: {exc}")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure custom regex patterns use raw string literals
- add QA number regex patterns
- add unit test for QA_NUMBER_PATTERNS

## Testing
- `ruff check .` *(fails: many existing issues)*
- `pytest tests/test_custom_patterns_unit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f3510a354832e9fd4811ff6d8536c