### PR TITLE
Improve LED status colors and tests

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -34,7 +34,7 @@ def get_led_colors(status):
         "OCR": (BRAND_COLORS.get("accent_blue"), BRAND_COLORS.get("status_ocr_bg")),
         "AI": (BRAND_COLORS.get("kyocera_red"), BRAND_COLORS.get("status_ai_bg")),
         "Paused": (BRAND_COLORS.get("warning_orange"), BRAND_COLORS.get("status_default_bg")),
-        "Ready": ("gray", BRAND_COLORS.get("status_default_bg")),
+        "Ready": (BRAND_COLORS.get("success_green"), BRAND_COLORS.get("status_default_bg")),
         "Complete": (BRAND_COLORS.get("success_green"), BRAND_COLORS.get("status_default_bg")),
         "Cancelled": (BRAND_COLORS.get("warning_orange"), BRAND_COLORS.get("status_default_bg")),
         "Error": (BRAND_COLORS.get("fail_red"), BRAND_COLORS.get("status_default_bg")),
@@ -439,7 +439,7 @@ class KyoQAToolApp(tk.Tk):
     def set_led(self, status):
         """Update the small status LED and bar colour."""
         color_map = {
-            "Ready": BRAND_COLORS.get("accent_blue"),
+        "Ready": BRAND_COLORS.get("success_green"),
             "Processing": BRAND_COLORS.get("success_green"),
             "Paused": BRAND_COLORS.get("warning_orange"),
             "OCR": BRAND_COLORS.get("warning_orange"),

--- a/test_led_logic.py
+++ b/test_led_logic.py
@@ -19,6 +19,13 @@ class TestLEDColors(unittest.TestCase):
         self.assertEqual(fg, BRAND_COLORS["kyocera_black"])
         self.assertEqual(bg, BRAND_COLORS["status_default_bg"])
 
+    def test_ready_and_error(self):
+        fg_ready, _ = get_led_colors("Ready")
+        self.assertEqual(fg_ready, BRAND_COLORS["success_green"])
+
+        fg_error, _ = get_led_colors("Error")
+        self.assertEqual(fg_error, BRAND_COLORS["fail_red"])
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/tests/test_led.py
+++ b/tests/test_led.py
@@ -33,3 +33,16 @@ def test_set_led_processing():
     assert app.led_status_var.get() == "●"
     assert app.led_label.config_called["foreground"] == BRAND_COLORS["success_green"]
     assert app.status_frame.config_called["background"] == BRAND_COLORS["status_processing_bg"]
+
+
+def test_set_led_ready_and_error():
+    app = types.SimpleNamespace()
+    app.led_status_var = DummyVar()
+    app.led_label = DummyWidget()
+    app.status_frame = DummyWidget()
+
+    KyoQAToolApp.set_led(app, "Ready")
+    assert app.led_label.config_called["foreground"] == BRAND_COLORS["success_green"]
+
+    KyoQAToolApp.set_led(app, "Error")
+    assert app.led_label.config_called["foreground"] == BRAND_COLORS["fail_red"]


### PR DESCRIPTION
## Summary
- adjust LED color mapping to show green when ready and red when errors occur
- update set_led behavior to use new colors
- extend LED tests for Ready and Error states

## Testing
- `ruff check .` *(fails: many style issues across repo)*
- `pytest tests/test_led.py test_led_logic.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f35150924832e9c9e066adf93ff3e