### PR TITLE
Refine patterns and expand unit test coverage

### DIFF
--- a/custom_patterns.py
+++ b/custom_patterns.py
@@ -4,14 +4,14 @@
 MODEL_PATTERNS = [
     r"\bFS-\d+[A-Z]*\b",
     r"\bKM-\d+[A-Z]*\b",
-    r"\bECOSYS\s+[A-Z]+\d+[a-z]*\b",
-    r"\bTASKalfa\s+\d+[a-z]*\b",
-    r"\bPF-\d+\b",
-    r"\bDF-\d+\b",
-    r"\bMK-\d+\b",
-    r"\bDV-\d+\b",
-    r"\bTASKalfa Pro \d+c\b",
+    r"\bKM-C\d+[A-Z]*\b",
+    r"\bECOSYS\s+[A-Z]+\d+\w*\b",
+    r"\bTASKalfa\s+\d+\w*\b",
+    r"\b(?:PF|DF|MK|DV)-\d+\b",
     r"\bTASKalfa Pro \d+c\b",
 ]
 
-QA_NUMBER_PATTERNS = []
+QA_NUMBER_PATTERNS = [
+    r"\bQA-\d+\b",
+    r"\bSB-\d+\b",
+]

--- a/tests/test_custom_patterns_unit.py
+++ b/tests/test_custom_patterns_unit.py
@@ -8,11 +8,16 @@ class TestCustomPatterns(unittest.TestCase):
         self.assertEqual(custom_patterns.MODEL_PATTERNS[0], r"\bFS-\d+[A-Z]*\b")
 
     def test_patterns_compile(self):
-        for pat in custom_patterns.MODEL_PATTERNS:
+        """Ensure both model and QA patterns compile."""
+        for pat in custom_patterns.MODEL_PATTERNS + custom_patterns.QA_NUMBER_PATTERNS:
             try:
                 re.compile(pat)
             except re.error as exc:
                 self.fail(f"Pattern {pat} failed to compile: {exc}")
+
+    def test_qa_patterns_present(self):
+        """Check that QA patterns list is not empty."""
+        self.assertGreater(len(custom_patterns.QA_NUMBER_PATTERNS), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refine regex patterns for models and QA numbers
- ensure QA patterns list is not empty and compile

## Testing
- `python -m py_compile custom_patterns.py tests/test_custom_patterns_unit.py`
- `echo -e "1\n\n\n" | python test_custom_patterns.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f35183830832eb53c350180a52a08