### PR TITLE
Simplify version module and extend tests

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -15,3 +15,10 @@ def test_import_start_tool():
 def test_import_packaging_script():
     mod = importlib.import_module("packaging_script")
     assert mod.current_version == version.VERSION
+
+
+def test_print_header_uses_get_version(capsys):
+    start_mod = importlib.import_module("start_tool")
+    start_mod.print_header()
+    captured = capsys.readouterr().out
+    assert version.VERSION in captured

--- a/version.py
+++ b/version.py
@@ -1,9 +1,6 @@
-# version.py
-# Single source of truth for the application version.
 VERSION = "30.0.0"
 
 
 def get_version() -> str:
-    """Return the current application version."""
     return VERSION
 


### PR DESCRIPTION
## Summary
- tidy up version module
- add test ensuring print header uses version constant

## Testing
- `ruff check version.py packaging_script.py start_tool.py tests/test_version.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f344198b8832e9db4c019bbd6aa33