### PR TITLE
Add support for new rows in Excel generator

### DIFF
--- a/excel_generator.py
+++ b/excel_generator.py
@@ -31,6 +31,32 @@ STATUS_FILLS = {
     "No Text Found": PatternFill(start_color="FFC7CE", end_color="FFC7CE", fill_type="solid"),
 }
 
+DEFAULT_TEMPLATE_PATH = Path("Sample_Set/kb_knowledge_Template.xlsx")
+
+def _load_default_headers(path=DEFAULT_TEMPLATE_PATH):
+    try:
+        import zipfile, xml.etree.ElementTree as ET
+        with zipfile.ZipFile(path) as z:
+            shared = ET.fromstring(z.read("xl/sharedStrings.xml"))
+            strings = [t.text for t in shared.iter('{http://schemas.openxmlformats.org/spreadsheetml/2006/main}t')]
+            sheet = ET.fromstring(z.read("xl/worksheets/sheet1.xml"))
+            ns = {'m': 'http://schemas.openxmlformats.org/spreadsheetml/2006/main'}
+            first_row = sheet.find('.//m:sheetData/m:row', ns)
+            headers = []
+            for c in first_row:
+                v = c.find('m:v', ns)
+                if v is None:
+                    headers.append("")
+                elif c.get('t') == 's':
+                    headers.append(strings[int(v.text)])
+                else:
+                    headers.append(v.text)
+            return headers
+    except Exception:
+        return []
+
+DEFAULT_TEMPLATE_HEADERS = _load_default_headers()
+
 def sanitize_for_excel(value):
     """Sanitizes a value to be safely written to an Excel cell."""
     if isinstance(value, str):
@@ -89,22 +115,37 @@ def generate_excel(all_results, output_path, template_path):
         if desc_col_idx == -1:
             raise ExcelGenerationError(f"Template missing required column: '{DESCRIPTION_COLUMN_NAME}'")
 
+        matched_keys = set()
         for row_num, row_cells in enumerate(worksheet.iter_rows(min_row=2), start=2):
             desc_val = row_cells[desc_col_idx].value
-            if not desc_val: continue
-            
+            if not desc_val:
+                continue
+
             row_key = Path(str(desc_val)).stem
             if row_key in new_data_df.index:
+                matched_keys.add(row_key)
                 new_row_data = new_data_df.loc[row_key]
-                
+
                 if meta_col_idx != -1 and META_COLUMN_NAME in new_row_data:
                     worksheet.cell(row=row_num, column=meta_col_idx + 1).value = new_row_data[META_COLUMN_NAME]
                 if author_col_idx != -1 and AUTHOR_COLUMN_NAME in new_row_data:
                     worksheet.cell(row=row_num, column=author_col_idx + 1).value = new_row_data[AUTHOR_COLUMN_NAME]
-                
+
                 if fill := STATUS_FILLS.get(new_row_data['processing_status']):
                     for cell in row_cells:
                         cell.fill = fill
+
+        missing_keys = [k for k in new_data_df.index if k not in matched_keys]
+        if missing_keys:
+            log_info(logger, f"Appending {len(missing_keys)} new row(s) to template")
+        for key in missing_keys:
+            new_row_data = new_data_df.loc[key]
+            new_row = [new_row_data.get(col, "") for col in header]
+            worksheet.append(new_row)
+            row_cells = list(worksheet.iter_rows(min_row=worksheet.max_row, max_row=worksheet.max_row))[0]
+            if fill := STATUS_FILLS.get(new_row_data['processing_status']):
+                for cell in row_cells:
+                    cell.fill = fill
 
         apply_styles(worksheet)
         workbook.save(output_path)

--- a/test_excel_generator.py
+++ b/test_excel_generator.py
@@ -46,3 +46,25 @@ def test_generate_excel_with_template(tmp_path):
     assert ws.max_row == 2
     sd_index = DEFAULT_TEMPLATE_HEADERS.index("Short description") + 1
     assert ws.cell(row=2, column=sd_index).value == "Test"
+
+
+def test_generate_excel_appends_missing_rows(tmp_path):
+    sample_df = pd.DataFrame([
+        {"file_name": "existing.pdf", "Short description": "Existing", "processing_status": "Success"},
+        {"file_name": "new.pdf", "Short description": "New Entry", "processing_status": "Success"},
+    ])
+
+    # Create a simple template with one existing row
+    template_path = tmp_path / "template.xlsx"
+    wb = load_workbook(Path("Sample_Set/kb_knowledge_Template.xlsx"))
+    ws = wb.active
+    ws.delete_rows(2, ws.max_row - 1)
+    ws.cell(row=2, column=DEFAULT_TEMPLATE_HEADERS.index("Short description") + 1).value = "existing"
+    wb.save(template_path)
+
+    output_file = tmp_path / "out_append.xlsx"
+    generate_excel(sample_df.to_dict("records"), output_file, template_path)
+
+    wb = load_workbook(output_file)
+    ws = wb.active
+    assert ws.max_row == 3


### PR DESCRIPTION
## Summary
- detect unmatched entries in generate_excel
- append new worksheet rows when needed and log action
- generate default headers from the template if openpyxl isn't available
- add regression test for appending rows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68733d9a2330832ea980c734c2156671