### PR TITLE
Fix headless startup and add test

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -401,4 +401,9 @@ class KyoQAToolApp(tk.Tk):
         self.start_processing(job={"excel_path": self.result_file_path, "input_path": files_to_rerun, "is_rerun": True})
 
 if __name__ == '__main__':
-    messagebox.showinfo("Launcher", "This script is not meant to be run directly.\nPlease use the 'run.py' script to launch the application.")
+    try:
+        app = KyoQAToolApp()
+        app.mainloop()
+    except tk.TclError as exc:  # pragma: no cover - display may be unavailable
+        print("No GUI display available - application cannot start.")
+        print(exc)

--- a/tests/test_app_startup.py
+++ b/tests/test_app_startup.py
@@ -1,0 +1,11 @@
+import os
+import sys
+import subprocess
+
+
+def test_script_runs_without_display():
+    env = dict(os.environ)
+    env.pop('DISPLAY', None)
+    result = subprocess.run([sys.executable, 'kyo_qa_tool_app.py'], env=env, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'No GUI display' in result.stdout


### PR DESCRIPTION
## Summary
- handle missing display when launching `KyoQAToolApp`
- test that the script exits cleanly in headless mode

## Testing
- `python -m py_compile kyo_qa_tool_app.py gui_components.py tests/test_app_startup.py`
- `pytest tests/test_app_startup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68741e9247b0832e8b6d4e86a41f28c1