### PR TITLE
Add simple backend wrapper and tests

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -31,7 +31,10 @@ def process_job(excel_path: str, pdf_paths: list[str], *, is_rerun: bool = False
 
     final: dict = {}
     while True:  # Consume progress messages until the job finishes
-        msg = q.get()
+        try:
+            msg = q.get(timeout=10)  # Add a timeout to prevent indefinite blocking
+        except queue.Empty:
+            raise RuntimeError("Timeout waiting for job to finish. No message received.")
         if msg.get("type") == "finish":
             final["status"] = msg.get("status")
             final["results"] = msg.get("results", [])

--- a/backend.py
+++ b/backend.py
@@ -1,24 +1,41 @@
+"""Simple synchronous wrapper around :func:`run_processing_job`."""
+
+import tempfile
+import shutil
 from queue import Queue
+
 from processing_engine import run_processing_job
 
 
-def process_job(excel_path: str, pdf_paths: list[str], is_rerun: bool = False) -> dict:
-    """Runs the full PDF→Excel pipeline synchronously.
-    Returns a dict with keys: status, results, output_path."""
+def process_job(excel_path: str, pdf_paths: list[str], *, is_rerun: bool = False) -> dict:
+    """Run the PDF→Excel pipeline and wait for completion.
+
+    Parameters
+    ----------
+    excel_path : str
+        Path to the Excel template to use.
+    pdf_paths : list[str]
+        Paths of PDF files to process.
+    is_rerun : bool, optional
+        If ``True``, ignore cached data and re-process PDFs, by default ``False``.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``status``, ``results`` and ``output_path`` keys.
+    """
+
     job = {"excel_path": excel_path, "input_path": pdf_paths, "is_rerun": is_rerun}
     q = Queue()
     run_processing_job(job, q)
-    final = {}
-    while True:
-        try:
-            msg = q.get(timeout=10)  # Timeout after 10 seconds
-        except queue.Empty:
-            raise TimeoutError("Processing job timed out waiting for a 'finish' message.")
-        except Exception as e:
-            raise RuntimeError(f"An error occurred while processing the job: {e}")
+
+    final: dict = {}
+    while True:  # Consume progress messages until the job finishes
+        msg = q.get()
         if msg.get("type") == "finish":
             final["status"] = msg.get("status")
             final["results"] = msg.get("results", [])
             break
+
     final["output_path"] = excel_path
     return final

--- a/test_backend.py
+++ b/test_backend.py
@@ -21,5 +21,23 @@ def test_process_job(monkeypatch):
 
     monkeypatch.setattr(backend, "run_processing_job", fake_run_processing_job)
 
-    result = backend.process_job("out.xlsx", ["a.pdf"], False)
+    result = backend.process_job("out.xlsx", ["a.pdf"], is_rerun=False)
     assert result == {"status": "Complete", "results": [1, 2, 3], "output_path": "out.xlsx"}
+
+
+def test_process_job_passes_job_info(monkeypatch):
+    captured = {}
+
+    def fake_run_processing_job(job, q):
+        captured.update(job)
+        q.put({"type": "finish", "status": "OK"})
+
+    monkeypatch.setattr(backend, "run_processing_job", fake_run_processing_job)
+
+    backend.process_job("template.xlsx", ["file1.pdf", "file2.pdf"], is_rerun=True)
+
+    assert captured == {
+        "excel_path": "template.xlsx",
+        "input_path": ["file1.pdf", "file2.pdf"],
+        "is_rerun": True,
+    }


### PR DESCRIPTION
## Summary
- simplify `process_job` in `backend.py`
- update tests for the new interface
- add regression test for job info handling

## Testing
- `python -m py_compile backend.py test_backend.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b19383730832e8a54b292ef48bb82