### PR TITLE
Add Flask server with API endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,0 +1,48 @@
+import os
+import shutil
+import tempfile
+from flask import Flask, request, abort, send_file, render_template
+from werkzeug.utils import secure_filename
+
+from backend import process_job
+
+app = Flask(__name__, static_folder="web", template_folder="web")
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/api/process", methods=["POST"])
+def api_process():
+    excel = request.files.get("excel")
+    pdfs = request.files.getlist("pdfs[]")
+    if not excel or not pdfs:
+        return abort(400, "Missing excel or pdfs[]")
+
+    workdir = tempfile.mkdtemp(prefix="qa_tool_")
+    try:
+        excel_fname = secure_filename(excel.filename)
+        excel_path = os.path.join(workdir, excel_fname)
+        excel.save(excel_path)
+
+        pdf_paths = []
+        for f in pdfs:
+            p = os.path.join(workdir, secure_filename(f.filename))
+            f.save(p)
+            pdf_paths.append(p)
+
+        _ = process_job(excel_path, pdf_paths)
+
+        return send_file(
+            excel_path,
+            as_attachment=True,
+            download_name=excel_fname,
+        )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=5000)

--- a/test_server.py
+++ b/test_server.py
@@ -1,0 +1,32 @@
+import io
+import pytest
+
+pytest.importorskip("flask")
+
+import server
+
+
+def test_api_process(monkeypatch):
+    called = {}
+
+    def fake_process(excel, pdfs):
+        called["excel"] = excel
+        called["pdfs"] = pdfs
+        return {"status": "OK", "results": [], "output_path": excel}
+
+    monkeypatch.setattr(server, "process_job", fake_process)
+
+    client = server.app.test_client()
+    data = {
+        "excel": (io.BytesIO(b"excel"), "template.xlsx"),
+        "pdfs[]": [
+            (io.BytesIO(b"pdf1"), "a.pdf"),
+            (io.BytesIO(b"pdf2"), "b.pdf"),
+        ],
+    }
+    resp = client.post("/api/process", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert called["pdfs"][0].endswith("a.pdf")
+    assert resp.data == b"excel"
+
+


### PR DESCRIPTION
## Summary
- implement `server.py` Flask app with `/api/process` endpoint
- add unit test for the new endpoint

## Testing
- `ruff check server.py test_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1b3a1714832ea8b997c88aaf2cdb