### PR TITLE
Add packaging support with setup.py and entry script

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include web *
+recursive-include assets *

--- a/launch.py
+++ b/launch.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import threading
 import time
+import os
 
 import webview
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="kyo-qa-tool",
+    version="25.1.1",
+    description="Kyocera QA ServiceNow Knowledge Tool (PDF→Excel) with web UI",
+    packages=find_packages(exclude=["web*", "tests*"]),
+    include_package_data=True,
+    install_requires=[
+        "Flask>=2.0", "Werkzeug>=2.0",
+        "openpyxl", "Pillow", "pywebview"
+    ],
+    entry_points={
+        "console_scripts": [
+            "kyo-qa=launch:main",
+        ],
+    },
+)

--- a/test_launch.py
+++ b/test_launch.py
@@ -23,8 +23,11 @@ def test_launch_main_starts_webview(monkeypatch):
 
     calls = []
 
+    def create_window(*a, **k):
+        calls.append(k.get("url", a[1] if len(a) > 1 else ""))
+
     stub_webview = types.SimpleNamespace(
-        create_window=lambda *a, **k: calls.append("window"),
+        create_window=create_window,
         start=lambda: calls.append("webview"),
     )
     monkeypatch.setitem(sys.modules, "webview", stub_webview)
@@ -47,9 +50,10 @@ def test_launch_main_starts_webview(monkeypatch):
     monkeypatch.setattr(launch, "time", types.SimpleNamespace(sleep=lambda x: None))
     monkeypatch.setattr(launch.subprocess, "run", lambda *a, **k: calls.append("run"))
 
+    monkeypatch.setenv("SERVER_URL", "http://example.com")
     launch.main()
 
     assert "run" in calls
-    assert "window" in calls
+    assert "http://example.com" in calls
     assert "webview" in calls
 


### PR DESCRIPTION
## Summary
- fix missing import in `launch.py` so `os.getenv` works
- ensure `kyo-qa` console script via new `setup.py`
- bundle web and asset files with `MANIFEST.in`
- adjust tests to cover environment variable usage when launching

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1fdc20a0832e8609155ad95dd4b5